### PR TITLE
deal with esri's default values

### DIFF
--- a/propagator/tests/test_toolbox.py
+++ b/propagator/tests/test_toolbox.py
@@ -358,7 +358,7 @@ class Test_Propagator(BaseToolboxChecker_Mixin):
     def test_analyze(self):
         tbx = toolbox.Propagator()
         ws = resource_filename('propagator.testing', 'tbx_propagate')
-        columns = 'Dry_B Average;Dry_M Median;Dry_N Min;Wet_B Max;Wet_M Average;Wet_N Median'
+        columns = 'Dry_B Average;Dry_M Median;Dry_N Min;Wet_B Max;Wet_M #;Wet_N Median'
         with mock.patch.object(toolbox.Propagator, '_add_to_map') as atm:
             subc_layer, stream_layer = tbx.analyze(
                 workspace=ws,
@@ -396,7 +396,7 @@ class Test_Propagator(BaseToolboxChecker_Mixin):
     def test_analyze_filter(self):
         tbx = toolbox.Propagator()
         ws = resource_filename('propagator.testing', 'tbx_propagate')
-        columns = 'Dry_B Average;Dry_M Median;Dry_N Min;Wet_B Max;Wet_M Average;Wet_N Median'
+        columns = 'Dry_B #;Dry_M Median;Dry_N Min;Wet_B Max;Wet_M Average;Wet_N Median'
         stacol = 'StationTyp'
         with mock.patch.object(toolbox.Propagator, '_add_to_map') as atm:
             subc_layer, stream_layer = tbx.analyze(

--- a/propagator/toolbox.py
+++ b/propagator/toolbox.py
@@ -432,7 +432,7 @@ class Propagator(base_tbx.BaseToolbox_Mixin):
 
         validate.non_empty_list(included_ml_types, on_fail='create')
 
-        value_columns = [vc.split(' ') for vc in value_cols_string.split(';')]
+        value_columns = [vc.split(' ') for vc in value_cols_string.replace(' #', ' average').split(';')]
         utils._status(value_columns, asMessage=True, verbose=True)
 
         if ml_type_col is not None:


### PR DESCRIPTION
esri doesn't pass None with an optional argument isn't specified.
instead it passes "#". This handles that for the statistics.

```
F:\phobson\SOC_WQIP\python-propagator>nosetests --with-coverage --cover-package=propagator
.........................................................................
.........................................................................
................................
Name                     Stmts   Miss  Cover   Missing
------------------------------------------------------
propagator.py                3      0   100%
propagator\analysis.py     139      1    99%   736
propagator\base_tbx.py      66      1    98%   182
propagator\toolbox.py      158      3    98%   385, 389, 391
propagator\utils.py        260      4    98%   199-200, 689, 1469
propagator\validate.py      29      1    97%   143
------------------------------------------------------
TOTAL                      655     10    98%
----------------------------------------------------------------------
Ran 178 tests in 32.292s

OK
```