### PR TITLE
Deleted two temporary status messages

### DIFF
--- a/propagator/toolbox.py
+++ b/propagator/toolbox.py
@@ -619,9 +619,7 @@ class Accumulator(base_tbx.BaseToolbox_Mixin):
         downstream_ID_col = params.pop('downstream_ID_column', None)
         # value columns and aggregations
         value_cols_string = params.pop('value_columns', None)
-        utils._status(value_cols_string, True, True)
         value_columns = [vc.split(' ') for vc in value_cols_string.replace(' #', ' average').split(';')]
-        utils._status(value_columns, True, True)
 
         streams = params.pop('streams', None)
         output_layer = params.pop('output_layer', None)


### PR DESCRIPTION
Coverage Results

```
C:\Users\cfang\Documents\GitHub\python-propagator [multi_agg_verify]> nosetests --with-coverage --cover-package=propagat
or
................................................................................F.......................................
..................................................................
======================================================================
FAIL: propagator.tests.test_utils.Test_Extension.test_unlicensed_extension
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\cfang\AppData\Local\Continuum\Anaconda2_32\lib\site-packages\nose\case.py", line 197, in runTest
    self.test(*self.arg)
  File "C:\Users\cfang\AppData\Local\Continuum\Anaconda2_32\lib\site-packages\nose\tools\nontrivial.py", line 67, in new
func
    raise AssertionError(message)
AssertionError: test_unlicensed_extension() did not raise RuntimeError

Name                     Stmts   Miss  Cover   Missing
------------------------------------------------------
propagator.py                3      0   100%
propagator\analysis.py     153      0   100%
propagator\base_tbx.py      79      1    99%   186
propagator\toolbox.py      183      0   100%
propagator\utils.py        262      6    98%   199-200, 318, 689, 1496-1497
propagator\validate.py      29      0   100%
------------------------------------------------------
TOTAL                      709      7    99%
----------------------------------------------------------------------
Ran 186 tests in 60.841s

FAILED (failures=1)
```

@phobson need to use a different extension to raise unlicensed error for any advanced license  holder
